### PR TITLE
Test : 데이터 수집

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,3 @@ RUN pip install requests \
 COPY src ${LAMBDA_TASK_ROOT}/src
 COPY src/etl/handler.py ${LAMBDA_TASK_ROOT}/handler.py
 CMD [ "handler.handler" ]
-# ENTRYPOINT [ "/bin/bash" , "test/test_handler.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM sykim98/aws-lambda-python-web-scrapping:0.1.0
 RUN pip install requests \ 
-    pip install boto3
+    pip install boto3 \
+    pip install ratelimit
 COPY src ${LAMBDA_TASK_ROOT}/src
 COPY src/etl/handler.py ${LAMBDA_TASK_ROOT}/handler.py
 CMD [ "handler.handler" ]

--- a/invoke.sh
+++ b/invoke.sh
@@ -2,9 +2,35 @@
 DOCKER_IMAGE="docker-image"
 DOCKER_TAG="test"
 PORT=8080
+CONTAINER_NAME="scrapper-container"
+CATEGORY_LIST_JSON_PATH="./src/etl/utils/static/book_category_url.json"
 
 echo "docker local test"
-docker build -t $DOCKER_IMAGE:$DOCKER_TAG .
-docker run -d -p ${PORT}:${PORT} --env-file .env ${DOCKER_IMAGE}:${DOCKER_TAG}
 
-curl "http://localhost:${PORT}/2015-03-31/functions/function/invocations" -d '{}'
+# docker-image:test 이미지 기반으로 컨테이너 exec
+# docker build -t $DOCKER_IMAGE:$DOCKER_TAG .
+
+category_lists=($(jq ". | keys[]" ${CATEGORY_LIST_JSON_PATH}))
+
+for c in ${category_lists[@]}; do
+    echo $c
+    docker run -d \
+        -p ${PORT}:${PORT} \
+        --env-file .env \
+        -v ./src/etl:/var/task \
+        --name ${CONTAINER_NAME} \
+        ${DOCKER_IMAGE}:${DOCKER_TAG} \
+
+    tmp="${c%\"}"
+    tmp="${tmp#\"}"
+
+    curl "http://localhost:8080/2015-03-31/functions/function/invocations" -d "{\"category\": [\"$tmp\"]}"
+
+    docker stop ${CONTAINER_NAME} 
+    docker rm ${CONTAINER_NAME} 
+done
+
+'''
+docker run -d -p 8080:8080 --env-file .env -v ./src/etl:/var/task docker-image:test
+curl "http://localhost:8080/2015-03-31/functions/function/invocations" -d '{"category" : ["취업", "IT"]}'
+'''

--- a/serverless.yml
+++ b/serverless.yml
@@ -24,5 +24,5 @@ functions:
       - schedule:
           rate: cron(0 12 ? * TUE *)
           input:
-          category: '소설'
+            category: '소설'
        

--- a/src/etl/crawling/book_data_scrapper.py
+++ b/src/etl/crawling/book_data_scrapper.py
@@ -21,9 +21,7 @@ class BookDataScrapper():
                time.sleep(random.uniform(1, 3))
                self.driver.get(url)
                bid = url.split("bid=")[1]
-
                book_data = self.get_book_data(BeautifulSoup(self.driver.page_source, 'html.parser'))
-
                if book_data is None: continue
                
                title, subtitle, author, description, image = book_data
@@ -36,14 +34,21 @@ class BookDataScrapper():
                      'rank':str(20*(page-1)+index+1), 
                      'description':description, 
                      'category':code}
-      
+
    @staticmethod
    def get_book_data(bsObject):
-      title = bsObject.find('h2', {'class': 'bookTitle_book_name__JuBQ2'}).text
-      subtitle = bsObject.find('span', {'class': 'bookTitle_sub_title__B0uMS'}).text
-      author = bsObject.find('span', {'class': 'bookTitle_inner_content__REoK1'}).text
-      description = bsObject.find('div', {'class': 'bookIntro_introduce_area__NJbWv'}).text
-      image = bsObject.find('div', {'class': 'bookImage_img_wrap__HWUgc'}).find('img')['src']
+      def get_text(tag: str, class_name: str) -> str:
+         element = bsObject.find(tag, {'class': class_name})
+         return element.text if element else ''
+
+      title = get_text('h2', 'bookTitle_book_name__JuBQ2')
+      subtitle = get_text('span', 'bookTitle_sub_title__B0uMS')
+      author = get_text('span', 'bookTitle_inner_content__REoK1')
+      description = get_text('div', 'bookIntro_introduce_area__NJbWv')
+      try:
+         image = bsObject.find('div', {'class': 'bookImage_img_wrap__HWUgc'}).find('img')['src']
+      except:
+         image = ''
 
       return [title, subtitle, author, description, image]  
 

--- a/src/etl/crawling/book_data_scrapper.py
+++ b/src/etl/crawling/book_data_scrapper.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup
 import time, random
+from ratelimit import limits, sleep_and_retry
 
 
 class BookDataScrapper():
@@ -7,6 +8,8 @@ class BookDataScrapper():
       self.driver = chrome
       self.book_page_url = book_page_url
    
+   @sleep_and_retry
+   @limits(calls=1, period=2) # one request per 2 secs
    def crawl_books(self): 
       """
       리스트로 받아온 책의 각 세부 url 안에 들어가서 순위, 제목, 저자, 이미지, 책내용 받아오기

--- a/src/etl/crawling/book_url_getter.py
+++ b/src/etl/crawling/book_url_getter.py
@@ -1,11 +1,11 @@
 import os, json
 from bs4 import BeautifulSoup
 
-from etl.utils.config import get_workdir
+from utils.config import get_workdir
 
 
 class BookURLGetter:
-    def __init__(self, chrome: object, category: list) -> None:
+    def __init__(self, chrome: object, category: str) -> None:
         self.driver = chrome
         self.workdir = get_workdir()
         self.category = category
@@ -22,7 +22,7 @@ class BookURLGetter:
         """
         static json file로 카페고리 별 url 정보 저장되어있는 데이터 리턴
         """
-        book_category_filename = "etl/utils/static/book_category_url.json"
+        book_category_filename = "utils/static/book_category_url.json"
         with open(os.path.join(self.workdir, book_category_filename)) as f:
             url = json.load(f)
         self.book_category_url = url[self.category]

--- a/src/etl/crawling/book_url_getter.py
+++ b/src/etl/crawling/book_url_getter.py
@@ -1,7 +1,7 @@
 import os, json
 from bs4 import BeautifulSoup
 
-from src.etl.utils.config import get_workdir
+from etl.utils.config import get_workdir
 
 
 class BookURLGetter:

--- a/src/etl/dynamo_tables.py
+++ b/src/etl/dynamo_tables.py
@@ -1,0 +1,115 @@
+import logging
+import boto3
+from botocore.exceptions import ClientError
+from boto3.dynamodb.conditions import Key
+
+from utils.config import get_date, is_same_week
+
+
+logger = logging.getLogger(__name__)
+
+
+class DynamoTables():
+    def __init__(self, dyn_resource, table_name) -> None:
+        self.dyn_resource = dyn_resource
+        self.table=dyn_resource.Table(table_name)
+
+    def exists(self, table_name):
+        try:
+            table = self.dyn_resource.Table(table_name)
+            table.load()
+            exists = True
+        except ClientError as err:
+            if err.response["Error"]["Code"] == "ResourceNotFoundException":
+                exists = False
+            else:
+                logger.error(
+                    "Couldn't check for existence of %s. Here's why: %s: %s",
+                    table_name,
+                    err.response["Error"]["Code"],
+                    err.response["Error"]["Message"],
+                )
+                raise
+        else:
+            self.table = table
+        return exists
+    
+    def write_batch(self, books):
+        try:
+            with self.table.batch_writer() as writer:
+                for book in books:
+                    writer.put_item(Item=book)
+        except ClientError as err:
+            logger.error(
+                "Couln't load data into table %s. Here's why: %s %s",
+                self.table.name,
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+            raise
+
+    def add_item(self, info):
+        """
+        this method is tp add single item of given info parameter to the dynamo table.
+        - if the current table is related to book table, just add single book item.
+        - otherwise, if it's related to meta table, 
+            update the date and status info of the given category.
+        """
+        try:
+            if self.table.name == "ingested_book_table":
+                self.table.put_item(
+                    Item={
+                        "bid": info["bid"],
+                        "title": info["title"],
+                        "subtitle": info["subtitle"],
+                        "author": info["author"],
+                        "image": info["image"],
+                        "rank": info["rank"],
+                        "description": info["description"],
+                        "category": info["category"],
+                    }
+                )
+
+            if self.table.name == "metatable":
+                self.table.update_item(
+                    Key={"category":info['category']},
+                    UpdateExpression="set info.date=:date_val, info.statue=:status_val",
+                    ExpressionAttributeValues={":date_val": get_date(), 
+                                               ":status_val": info['status']},
+                    ReturnValues="UPDATED_NEW",
+                )
+
+        except ClientError as err:
+            logger.error(
+                "Couldn't add item of category %s to table %s. Here's why: %s: %s",
+                info["category"],
+                self.table.name,
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+            raise
+
+
+    def already_gathered_category(self, category):
+        """
+        this method is for check whether book data of 
+        category parameter was already scrapped or not.
+        """
+        try:
+            response = self.table.query(KeyConditionExpression=Key("category").eq(category))
+            scrapped_date = response["Items"]["date"]
+            scrapped_status = response["Items"]["status"]
+            if (is_same_week(scrapped_date) and scrapped_status == 'SUCCESS') \
+                or not is_same_week(scrapped_date):
+                return True
+
+        except ClientError as err:
+            logger.error(
+                "Couldn't query movies released in %s from table %s. Here's why: %s %s",
+                self.table.name,
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+            raise
+        else:
+            return False

--- a/src/etl/handler.py
+++ b/src/etl/handler.py
@@ -39,11 +39,11 @@ def handler(event=None, context=None, chrome=None):
     
     for c in event['category']:
         try:
-            book_table = DynamoTables(dynamodb, "ingested_book_table")
-            meta_table = DynamoTables(dynamodb, "metatable")
+            book_table = DynamoTables(dynamodb)
+            meta_table = DynamoTables(dynamodb)
 
-            if not book_table.exists() \
-                or not meta_table.exists() \
+            if not book_table.exists("ingested_book_table") \
+                or not meta_table.exists("metatable") \
                 or meta_table.already_gathered_category(c):
                 continue
 

--- a/src/etl/handler.py
+++ b/src/etl/handler.py
@@ -7,8 +7,8 @@ from botocore.exceptions import ClientError
 import json
 import os
 
-from src.etl.crawling.book_data_scrapper import BookDataScrapper
-from src.etl.crawling.book_url_getter import BookURLGetter
+from etl.crawling.book_data_scrapper import BookDataScrapper
+from etl.crawling.book_url_getter import BookURLGetter
 
 os.environ['AWS_DEFAULT_REGION'] = "ap-northeast-2"
 os.environ['TABLE_NAME'] = "ingested_book_table"
@@ -18,32 +18,35 @@ table_name = os.environ['TABLE_NAME']
 table = dynamodb.Table(table_name)
 
 def handler(event=None, context=None, chrome=None):
-    if chrome is None:
-        options = webdriver.ChromeOptions()
-        service = webdriver.ChromeService("/opt/chromedriver")
 
-        options.binary_location = '/opt/chrome/chrome'
-        options.add_argument("--headless=new")
-        options.add_argument('--no-sandbox')
-        options.add_argument("--disable-gpu")
-        options.add_argument("--window-size=1280x1696")
-        options.add_argument("--single-process")
-        options.add_argument("--disable-dev-shm-usage")
-        options.add_argument("--disable-dev-tools")
-        options.add_argument("--no-zygote")
-        options.add_argument(f"--user-data-dir={mkdtemp()}")
-        options.add_argument(f"--data-path={mkdtemp()}")
-        options.add_argument(f"--disk-cache-dir={mkdtemp()}")
-        options.add_argument("--remote-debugging-port=9222")
-        options.add_argument("--user-agent='Mozilla/5.0")
+    def driver_getter(chrome=None):
+        if chrome is None:
+            options = webdriver.ChromeOptions()
+            service = webdriver.ChromeService("/opt/chromedriver")
 
-        chrome = webdriver.Chrome(options=options, service=service)
+            options.binary_location = '/opt/chrome/chrome'
+            options.add_argument("--headless=new")
+            options.add_argument('--no-sandbox')
+            options.add_argument("--disable-gpu")
+            options.add_argument("--window-size=1280x1696")
+            options.add_argument("--single-process")
+            options.add_argument("--disable-dev-shm-usage")
+            options.add_argument("--disable-dev-tools")
+            options.add_argument("--no-zygote")
+            options.add_argument(f"--user-data-dir={mkdtemp()}")
+            options.add_argument(f"--data-path={mkdtemp()}")
+            options.add_argument(f"--disk-cache-dir={mkdtemp()}")
+            options.add_argument("--remote-debugging-port=9222")
+            options.add_argument("--user-agent='Mozilla/5.0")
 
-    url_getter = BookURLGetter(chrome, event['category'])
+            return webdriver.Chrome(options=options, service=service)
+        return chrome
+
+    url_getter = BookURLGetter(driver_getter(), event['category'])
     url_getter.get_book_page_urls_scrapper()
     book_page_url = url_getter.get_book_page_url()
     
-    scrapper = BookDataScrapper(chrome, book_page_url)
+    scrapper = BookDataScrapper(driver_getter(), book_page_url)
     for book_info in scrapper.crawl_books():
         print(book_info)
         table.put_item(Item=book_info)
@@ -51,3 +54,8 @@ def handler(event=None, context=None, chrome=None):
     return
 
 
+if __name__ == '__main__':
+    # handler(event={'category' : '소설'}, context=None, chrome=None)
+    handler(event={'category' : '시'}, context=None, chrome=None)
+    handler(event={'category' : '에세이1'}, context=None, chrome=None)
+    handler(event={'category' : '에세이2'}, context=None, chrome=None)

--- a/src/etl/handler.py
+++ b/src/etl/handler.py
@@ -41,15 +41,16 @@ def handler(event=None, context=None, chrome=None):
 
             return webdriver.Chrome(options=options, service=service)
         return chrome
-
-    url_getter = BookURLGetter(driver_getter(), event['category'])
-    url_getter.get_book_page_urls_scrapper()
-    book_page_url = url_getter.get_book_page_url()
     
-    scrapper = BookDataScrapper(driver_getter(), book_page_url)
-    for book_info in scrapper.crawl_books():
-        print(book_info)
-        table.put_item(Item=book_info)
+    for c in event['category']:
+        url_getter = BookURLGetter(chrome=driver_getter(), category=c)
+        url_getter.get_book_page_urls_scrapper()
+        book_page_url = url_getter.get_book_page_url()
+        
+        scrapper = BookDataScrapper(chrome=driver_getter(), book_page_url=book_page_url)
+        for book_info in scrapper.crawl_books():
+            print(book_info)
+            table.put_item(Item=book_info)
 
     return
 

--- a/src/etl/utils/config.py
+++ b/src/etl/utils/config.py
@@ -4,4 +4,6 @@ def get_workdir():
     """
     return project abs path string
     """
+    if os.environ.get('PYTHONPATH') == "'/var/task'":
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     return os.path.abspath(os.path.join(os.path.join(os.path.dirname(__file__), os.pardir), os.pardir))

--- a/src/etl/utils/config.py
+++ b/src/etl/utils/config.py
@@ -1,9 +1,12 @@
-import os
-
 def get_workdir():
+    import os
     """
     return project abs path string
     """
-    if os.environ.get('PYTHONPATH') == "'/var/task'":
+    if os.environ.get('PYTHONPATH') == '/var/task':
         return os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
     return os.path.abspath(os.path.join(os.path.join(os.path.dirname(__file__), os.pardir), os.pardir))
+
+def get_date():
+    from datetime import date
+    return date.today()

--- a/src/etl/utils/config.py
+++ b/src/etl/utils/config.py
@@ -9,4 +9,12 @@ def get_workdir():
 
 def get_date():
     from datetime import date
-    return date.today()
+    return str(date.today())
+
+
+def is_same_week(dateString):
+    import datetime
+    d1 = datetime.datetime.strptime(dateString,'%Y-%m-%d')
+    d2 = datetime.datetime.today()
+    return d1.isocalendar()[1] == d2.isocalendar()[1] \
+              and d1.year == d2.year


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Related Issues
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#8 

## Descriptions
<!--- Describe your changes in detail -->
<!--- Write the points you want to focus on when reviewing -->

### 1. 데이터 수집
런타임 인터페이스 에뮬레이터 사용하여 로컬 환경에서 람다 실행, 데이터 수집

### 2. logging system 추가
- `metatable`을 생성하여 작업의 성공, 실패, 진행 여부에 대한 정보를 로깅한다. (완전 로깅 개념은 아님, 업데이트하는 개념)
- schema of metatable 
```
# **metatable 역시 dynamodb 의 table로, 스키마 없음. 기록을 위한 테이블 형태
date : string - 작업 완료된 시점의 날짜 문자열 yyyy-MM-dd 형태
category : string - 이들 중 하나의 값을 가짐) "IT", "가족" "공학", "과학", "문학/신학", "물리학", "사전", "사회학", "소설", "수험", "시", "시장","아동", "언어", 에세이1", "에세이2", "여행", 역사학", "예술","오락1", "오락2", "오락3", "유아", "인문학", "입시", "자기계발","자산", "잡지", "정치학", "종교","청소년공부", "취미1", "취미2", "취미3", 취미4", "취업", "해외도서1", "해외도서2", "해외도서3", "해외도서4", "해외도서5", "헬스케어" 
status : string - SUCCESS / FAIL
```

>🤔 some thoughts of writing to metatable...
데이터 수집 후 해당 카테고리에 수집 success/fail, 수집 날짜를 저장하는 방식에 대해 고민되는 부분
1. category - 수집 date를 계속 추가한다. 그니까 같은 카테고리 다른 수집 날짜가 계속 쌓이는 형태
2. 각 category에 대해서 가장 최신 overwrited date, 즉 가장 최근에 작업이 수행된 정보만 저장한다.

해당 테이블의 설계 목적은 한 카테고리에 대해서 계속 스크래핑이 중복으로 동작하지 않도록 하기 위함이다. 각 카테고리의 수집, 적재된 날짜를 확인하여 같은 주에 이미 수집이 되었다면 건너뛰고, 그렇지 않거나 status가 FAIL이면 다시 수집이 되도록 하기 위함이다.
따라서 이를 고려하면 2번이 더 적절할 것 같다. 메타테이블이 딱 지정된 용량으로 계속 유지될 수도 있고 더 깔끔해보인다.

--

### 3. 람다 실행 bash script 추가
- categoy 당 3~6개의 sub category 가 존재
- 하나의 category에 해당하는 스크래핑 람다가 도커 라이프사이클 한 바퀴를 담당
    - 42개의 cafegory 돌면서 
    - docker run 
    - -> create local endpoint & call handler with json payload (give category to lambda)
    - -> docker stop and remove

## Tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

invoke.sh 실행시켰을 때 42개의 상위 카테고리에 대해 도커 실행 -> 하위 카테고리에 해당하는 top 60개의 책 스크래핑 동작 확인
- metatable정보 확인하여 아직 수집되지 않은 카테고리에 대해서만 동작

## Screenshots (optional)
ingested_book_talbe example
<img width="927" alt="Screenshot 2024-01-25 at 3 57 34 PM" src="https://github.com/seoyeong98/Book-data-Pipeline/assets/52881652/66cf0b8f-dc87-45d7-b650-176721165060">
metatable example
<img width="400" alt="Screenshot 2024-01-25 at 3 57 13 PM" src="https://github.com/seoyeong98/Book-data-Pipeline/assets/52881652/b01af3f0-f6b9-4101-a296-ed9aceabc05a">


## Etc. (optional)

람다가 오토스케일링되는 형태는 아님. (단순 테스트 환경에서만 동작)
- naver scrapper 차단 문제를 해결하여 배포된 람다가 정상 동작한다면 데이터 수집 단계가 더 최적화될 수 있을 것 같다.
- 프록시 서버를 구매하여 aws lamdba ip를 우회해보는(?) 방법 - 추후 테스트 필요

